### PR TITLE
ルートをAPIモードに修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :books
+  namespace :api do
+    resources :books
+  end
   root to: "books#index"
 end


### PR DESCRIPTION
フロントをReactにするため、RailsはAPIとして利用する
そのためルートをAPI仕様に設定