### PR TITLE
要点・感想は空白を許容する

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -3,8 +3,8 @@ class Book < ApplicationRecord
   validates :author, presence: true
   validates :publisher, presence: true
   validates :status, presence: true
-  validates :gist, presence: true, length: { maximum: 5000 }
-  validates :impression, presence: true, length: { maximum: 10000 }
+  validates :gist, length: { maximum: 5000 }
+  validates :impression, length: { maximum: 10000 }
   validates :image, presence: true
 
   # クラスインスタンスメソッド


### PR DESCRIPTION
## 背景
実際に書籍の新規追加をしてみて、まだ読んでないものの要点や概要は書けないと思った。
どちらかと言うと編集画面で追記していくフローだと思われるので、空白を許容する

## 実装内容
- [x] 要点と感想のバリデーションを解除
空白を許容
文字数制限はそのまま