### PR TITLE
要点・感想の文字数を返す

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -27,7 +27,9 @@ class Book < ApplicationRecord
       status: self.status,
       gist: self.gist,
       impression: self.impression,
-      image: self.image
+      image: self.image,
+      gistWordCount: self.gist.length,
+      impressionWordCount: self.impression.length
     }
   end
 


### PR DESCRIPTION
## 背景
編集画面での要点と感想の文字数の初期値を設定するために、API側から文字数を返す

## 実装内容
- [x] 書籍詳細情報を返すメソッドに要点と感想の文字数を追加する